### PR TITLE
UI updates

### DIFF
--- a/upvpn-ui/src-tauri/src/main.rs
+++ b/upvpn-ui/src-tauri/src/main.rs
@@ -37,7 +37,13 @@ fn main() {
         use tauri::Submenu;
         let menu = Menu::new().add_submenu(Submenu::new(
             "upvpn",
-            Menu::new().add_native_item(MenuItem::CloseWindow),
+            Menu::new()
+                .add_native_item(MenuItem::Copy)
+                .add_native_item(MenuItem::Paste)
+                .add_native_item(MenuItem::SelectAll)
+                .add_native_item(MenuItem::Cut)
+                .add_native_item(MenuItem::Separator)
+                .add_native_item(MenuItem::CloseWindow),
         ));
         builder = builder.menu(menu);
     }

--- a/upvpn-ui/src/pages/Locations.tsx
+++ b/upvpn-ui/src/pages/Locations.tsx
@@ -97,6 +97,9 @@ const Locations = (props: Props) => {
             </button>
             <input
               type="text"
+              autoCorrect="off"
+              autoCapitalize="none"
+              autoFocus={true}
               placeholder="Search location"
               className="input input-bordered focus:ring-1 focus:outline-none hover:ring-1 w-full font-semibold"
               onChange={(e) => setSearch(e.target.value)}

--- a/upvpn-ui/src/pages/SignIn.tsx
+++ b/upvpn-ui/src/pages/SignIn.tsx
@@ -66,11 +66,12 @@ const SignIn = () => {
           <div className="card-body">
             <form onSubmit={onSubmit} >
               <div className="form-control">
-                <label className="label">
+                <label htmlFor="email" className="label">
                   <span className="label-text">Email</span>
                 </label>
 
                 <input
+                  name="email"
                   type="email"
                   autoCorrect="off"
                   autoCapitalize="none"
@@ -79,16 +80,18 @@ const SignIn = () => {
                   className="input input-bordered focus:ring-1 focus:outline-none hover:ring-1"
                   disabled={checking}
                   required
+                  autoFocus={true}
                 />
               </div>
               <div className="form-control">
-                <label className="label">
+                <label htmlFor="password" className="label">
                   <span className="label-text">Password</span>
                 </label>
                 <input
+                  name="password"
+                  type="password"
                   id="current-password"
                   autoComplete="current-password"
-                  type="password"
                   onChange={(e) => setPassword(e.target.value)}
                   className="input input-bordered focus:ring-1 focus:outline-none hover:ring-1"
                   disabled={checking}

--- a/upvpn-ui/src/pages/SignIn.tsx
+++ b/upvpn-ui/src/pages/SignIn.tsx
@@ -64,7 +64,7 @@ const SignIn = () => {
         </div>
         <div className="card flex-shrink-0 w-full max-w-sm shadow-2xl bg-base-100">
           <div className="card-body">
-            <form onSubmit={onSubmit}>
+            <form onSubmit={onSubmit} >
               <div className="form-control">
                 <label className="label">
                   <span className="label-text">Email</span>
@@ -72,8 +72,12 @@ const SignIn = () => {
 
                 <input
                   type="email"
+                  autoCorrect="off"
+                  autoCapitalize="none"
+                  autoComplete="email"
                   onChange={(e) => setEmail(e.target.value)}
                   className="input input-bordered focus:ring-1 focus:outline-none hover:ring-1"
+                  disabled={checking}
                   required
                 />
               </div>
@@ -82,9 +86,12 @@ const SignIn = () => {
                   <span className="label-text">Password</span>
                 </label>
                 <input
+                  id="current-password"
+                  autoComplete="current-password"
                   type="password"
                   onChange={(e) => setPassword(e.target.value)}
                   className="input input-bordered focus:ring-1 focus:outline-none hover:ring-1"
+                  disabled={checking}
                   required
                 />
                 <label className="label">
@@ -98,7 +105,7 @@ const SignIn = () => {
                 </label>
               </div>
               <div className="form-control mt-6">
-                <button className="btn btn-primary">
+                <button className="btn btn-primary" disabled={checking} >
                   {checking ? <Spinner className="w-12 h-12" /> : <>Sign In</>}
                 </button>
               </div>


### PR DESCRIPTION
- fix copy, paste, cut, selectall on macOS for sign in page 
- autofocus on email for sign-in page; autofocus on search box on locations page;
- disable sign-in form inputs when in progress