### PR TITLE
iOS and iPadOS app launch on the App Store

### DIFF
--- a/upvpn-apple/README.md
+++ b/upvpn-apple/README.md
@@ -1,13 +1,9 @@
-## UpVPN for macOS
+## UpVPN on Apple Platform
 
-Native macOS app built using the following modern Apple technologies: Swift, Swift concurrency, SwiftUI, and Network Extension.
+Native macOS, iOS and iPadOS app is built using the following modern Apple technologies: Swift, Swift concurrency, SwiftUI, and Network Extension.
 
 [Download it from the App Store](https://apps.apple.com/app/serverless-vpn-upvpn/id6596774170)
 
-The source code for the new app will be made available in this repo soon.
+The source code for the new apps will be made available in this repo soon.
 
-## UpVPN for iOS and iPadOS
-
-Register to get notified when UpVPN app for iOS and iPadOS becomes available:
-
-https://upvpn.app/vpn-for-ios-ipados/
+To learn more visit https://UpVPN.app/ios


### PR DESCRIPTION
iOS and iPadOS app is now available at https://apps.apple.com/app/serverless-vpn-upvpn/id6596774170